### PR TITLE
Convert time to float before creating messagepack.

### DIFF
--- a/lib/fluent/plugin/out_timescaledb.rb
+++ b/lib/fluent/plugin/out_timescaledb.rb
@@ -31,7 +31,7 @@ module Fluent
       end
 
       def format(tag, time, record)
-        [tag, time, record].to_msgpack
+        [tag, time.to_f, record].to_msgpack
       end
 
       def formatted_to_msgpack_binary


### PR DESCRIPTION
Otherwise it will be converted to an Integer, which will lose nanosecond data.